### PR TITLE
`actionsDict` is not bound to `this`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ When writing the `actionDict` (second parameter), it is expected that:
   - You write `actionsDict` directly inside the `createRedutser` call ("inline"), otherwise
   you'd need to duck-type the `State` type for every item.
 
+Using `this`? [See caveat](#this-usage).
 
 The returning object has the following properties:
 
@@ -159,10 +160,17 @@ const meatball = combineRedutsers(initialState, { itemA: innerA, itemB: innerB }
 ```
 
 
-## Known Caveats
+# Known Caveats
 
   - When actions have no parameters, you will still be required to pass an empty object `{}` to the payload.
   - (Redux) If using redux 3.x, you might want to disable `strictFunctionTypes` compiler options (thats a general redux+ts issue). `4.x` typings work great and are highly recommended.
+
+## <a name="this-usage"></a> Using `this` on createRedutser
+
+Typescript has inference issues when using `this` on createReducer ( [issue](https://github.com/wkrueger/redutser/issues/2) ). You may choose a new "curried" alternate version of the function: `createRedutser2(initialState)({ ...reducer })` which
+works better with the inference.
+
+
 
 ## Building
 

--- a/built/index.js
+++ b/built/index.js
@@ -2,6 +2,7 @@
 exports.__esModule = true;
 var redutser_1 = require("./redutser");
 exports.createRedutser = redutser_1.createRedutser;
+exports.createRedutser2 = redutser_1.createRedutser2;
 var subdomain_1 = require("./subdomain");
 exports.subdomain = subdomain_1.subdomain;
 exports.combineRedutsers = subdomain_1.combineRedutsers;

--- a/built/redutser.js
+++ b/built/redutser.js
@@ -12,15 +12,8 @@ function createRedutser(initialState, reducerDict) {
     var creators = _actionCreatorsFromReducerDict()(reducerDict);
     function reducer(state, action) {
         if (state === void 0) { state = initialState; }
-        if (initialState === undefined) {
-            console.error("redutser unexpected: undefined state.");
-        }
-        var handler = reducerDict[action.type];
-        if (handler) {
-            return handler(state, action.payload);
-        }
-        else if (String(action.type).substr(0, 2) !== "@@") {
-            console.error("redutser unexpected: handler not found for action", action.type);
+        if (reducerDict[action.type]) {
+            return reducerDict[action.type](state, action.payload);
         }
         return state;
     }

--- a/built/redutser.js
+++ b/built/redutser.js
@@ -8,7 +8,7 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
     return t;
 };
 exports.__esModule = true;
-function createRedutser(initialState, reducerDict) {
+exports.createRedutser2 = function (initialState) { return function (reducerDict) {
     var creators = _actionCreatorsFromReducerDict()(reducerDict);
     function reducer(state, action) {
         if (state === void 0) { state = initialState; }
@@ -25,8 +25,10 @@ function createRedutser(initialState, reducerDict) {
         __redutser__: true,
         _reducerDict: reducerDict
     };
-}
-exports.createRedutser = createRedutser;
+}; };
+exports.createRedutser = function (initialState, reducerDict) {
+    return exports.createRedutser2(initialState)(reducerDict);
+};
 function _actionCreatorsFromReducerDict() {
     return function (dict) {
         return Object.keys(dict).reduce(function (out, name) {

--- a/built/redutser.spec.js
+++ b/built/redutser.spec.js
@@ -48,4 +48,17 @@ describe("redutser", function () {
         store.dispatch(creators.doNothing({}));
         expect(store.getState()).toEqual({ a: 3, b: "bcc" });
     });
+    test("bind to self", function () {
+        var initialState = { a: 1 };
+        redutser_1.createRedutser(initialState, {
+            increment: function (state, act) {
+                return {
+                    a: state.a + act.by
+                };
+            },
+            times: function (state, act) {
+                return this.increment(state, { by: act.by * act.times });
+            }
+        });
+    });
 });

--- a/built/redutser.spec.js
+++ b/built/redutser.spec.js
@@ -50,7 +50,7 @@ describe("redutser", function () {
     });
     test("bind to self", function () {
         var initialState = { a: 1 };
-        redutser_1.createRedutser2(initialState)({
+        var red = redutser_1.createRedutser2(initialState)({
             increment: function (state, act) {
                 return {
                     a: state.a + act.by
@@ -60,5 +60,8 @@ describe("redutser", function () {
                 return this.increment(state, { by: act.by * act.times });
             }
         });
+        var store = redux_1.createStore(red.reducer);
+        store.dispatch(red.creators.times({ by: 2, times: 3 }));
+        expect(store.getState()).toEqual({ a: 7 });
     });
 });

--- a/built/redutser.spec.js
+++ b/built/redutser.spec.js
@@ -50,7 +50,7 @@ describe("redutser", function () {
     });
     test("bind to self", function () {
         var initialState = { a: 1 };
-        redutser_1.createRedutser(initialState, {
+        redutser_1.createRedutser2(initialState)({
             increment: function (state, act) {
                 return {
                     a: state.a + act.by

--- a/declaration/index.d.ts
+++ b/declaration/index.d.ts
@@ -1,4 +1,4 @@
-export { createRedutser, Redutser } from "./redutser";
+export { createRedutser, createRedutser2, Redutser } from "./redutser";
 export { subdomain, combineRedutsers } from "./subdomain";
 export { liftRedutserState, liftDictState } from "./combine-redutsers";
 export * from "../type-helpers";

--- a/declaration/redutser.d.ts
+++ b/declaration/redutser.d.ts
@@ -1,7 +1,7 @@
 import * as H from "../type-helpers";
 export declare type Reducer<State, Payload = any> = (s: State, p: Payload) => State;
 export declare type ReducerDict<State> = {
-    [name: string]: Reducer<State>;
+    [name: string]: (s: State, p: any) => State;
 };
 export declare type ActionCreatorsFromReducerDict<Inp extends ReducerDict<any>> = {
     [K in keyof Inp]: (payload: H.SecondArg<Inp[K]>) => {

--- a/declaration/redutser.d.ts
+++ b/declaration/redutser.d.ts
@@ -10,7 +10,8 @@ export declare type ActionCreatorsFromReducerDict<Inp extends ReducerDict<any>> 
     };
 };
 export declare type ActionTypesFromReducerDict<Inp extends ReducerDict<any>> = H.FnReturn<H.Values<ActionCreatorsFromReducerDict<Inp>>>;
-export declare function createRedutser<State, Dict extends ReducerDict<State>>(initialState: State, reducerDict: Dict): Redutser<State, Dict>;
+export declare const createRedutser2: <State>(initialState: State) => <Dict extends ReducerDict<State>>(reducerDict: Dict) => Redutser<State, Dict>;
+export declare const createRedutser: <State, Dict extends ReducerDict<State>>(initialState: State, reducerDict: Dict) => Redutser<State, Dict>;
 export interface Redutser<State, Dict extends ReducerDict<State>> {
     creators: ActionCreatorsFromReducerDict<Dict>;
     reducer: (state: State | undefined, action: H.FnReturn<ActionCreatorsFromReducerDict<Dict>[keyof Dict]>) => State;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redutser",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Type-safe action creators and reducers for redux.",
   "main": "built/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redutser",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Type-safe action creators and reducers for redux.",
   "main": "built/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { createRedutser, Redutser } from "./redutser"
+export { createRedutser, createRedutser2, Redutser } from "./redutser"
 export { subdomain, combineRedutsers } from "./subdomain"
 export { liftRedutserState, liftDictState } from "./combine-redutsers"
 

--- a/src/redutser.spec.ts
+++ b/src/redutser.spec.ts
@@ -56,7 +56,7 @@ describe("redutser", () => {
 
   test("bind to self", () => {
     const initialState = { a: 1 }
-    createRedutser2(initialState)({
+    const red = createRedutser2(initialState)({
       increment(state, act: { by: number }) {
         return {
           a: state.a + act.by,
@@ -66,5 +66,8 @@ describe("redutser", () => {
         return this.increment(state, { by: act.by * act.times })
       },
     })
+    const store = createStore(red.reducer)
+    store.dispatch(red.creators.times({ by: 2, times: 3 }))
+    expect(store.getState()).toEqual({ a: 7 })
   })
 })

--- a/src/redutser.spec.ts
+++ b/src/redutser.spec.ts
@@ -1,4 +1,4 @@
-import { createRedutser } from "./redutser"
+import { createRedutser, createRedutser2 } from "./redutser"
 import { createStore } from "redux"
 
 function createSomething() {
@@ -52,5 +52,19 @@ describe("redutser", () => {
 
     store.dispatch(creators.doNothing({}))
     expect(store.getState()).toEqual({ a: 3, b: "bcc" })
+  })
+
+  test("bind to self", () => {
+    const initialState = { a: 1 }
+    createRedutser2(initialState)({
+      increment(state, act: { by: number }) {
+        return {
+          a: state.a + act.by,
+        }
+      },
+      times(state, act: { by: number; times: number }) {
+        return this.increment(state, { by: act.by * act.times })
+      },
+    })
   })
 })

--- a/src/redutser.ts
+++ b/src/redutser.ts
@@ -3,7 +3,7 @@ import * as H from "../type-helpers"
 export type Reducer<State, Payload = any> = (s: State, p: Payload) => State
 
 export type ReducerDict<State> = {
-  [name: string]: Reducer<State>
+  [name: string]: (s: State, p: any) => State
 }
 
 export type ActionCreatorsFromReducerDict<Inp extends ReducerDict<any>> = {
@@ -16,28 +16,19 @@ export type ActionTypesFromReducerDict<
   Inp extends ReducerDict<any>
 > = H.FnReturn<H.Values<ActionCreatorsFromReducerDict<Inp>>>
 
-export function createRedutser<State, Dict extends ReducerDict<State>>(
-  initialState: State,
+export const createRedutser2 = <State>(initialState: State) => <
+  Dict extends ReducerDict<State>
+>(
   reducerDict: Dict
-): Redutser<State, Dict> {
+): Redutser<State, Dict> => {
   const creators = _actionCreatorsFromReducerDict()(reducerDict)
 
   function reducer(
     state = initialState,
     action: ActionTypesFromReducerDict<Dict>
   ): State {
-    if (initialState === undefined) {
-      console.error("redutser unexpected: undefined state.")
-    }
-
-    const handler = reducerDict[action.type]
-    if (handler) {
-      return handler(state, action.payload)
-    } else if (String(action.type).substr(0, 2) !== "@@") {
-      console.error(
-        "redutser unexpected: handler not found for action",
-        action.type
-      )
+    if (reducerDict[action.type]) {
+      return reducerDict[action.type](state, action.payload)
     }
     return state
   }
@@ -50,6 +41,13 @@ export function createRedutser<State, Dict extends ReducerDict<State>>(
     __redutser__: true,
     _reducerDict: reducerDict,
   }
+}
+
+export const createRedutser = <State, Dict extends ReducerDict<State>>(
+  initialState: State,
+  reducerDict: Dict
+) => {
+  return createRedutser2(initialState)(reducerDict)
 }
 
 // copy-pasted, maybe helps something


### PR DESCRIPTION
From #2 .
1. The "runtime" part of the function ( `function reducer()`) lost the binding the way it was written. Fix'd.
2. Some inference quirk brought strange typecheck issues when using "this". While at the moment I couldnt figure out one way to fix that without changing the signature (maybe with mapped types?), I ended up adding a "curried" version of the function, which works well with the inference on those cases.

(TS hasnt got a way to indicate function paremeter inference order or priority. Currying the parameters is a trick I found usually works fixing issues of that type).