### PR TITLE
Use buildin ReturnType

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jest": "^22.4.3",
     "redux": "^4.0.0-rc.1",
     "ts-jest": "^22.4.3",
-    "typescript": "^2.8.1"
+    "typescript": "~2.9.0"
   },
   "dependencies": {}
 }

--- a/src/redutser.ts
+++ b/src/redutser.ts
@@ -14,7 +14,7 @@ export type ActionCreatorsFromReducerDict<Inp extends ReducerDict<any>> = {
 
 export type ActionTypesFromReducerDict<
   Inp extends ReducerDict<any>
-> = H.FnReturn<H.Values<ActionCreatorsFromReducerDict<Inp>>>
+> = ReturnType<H.Values<ActionCreatorsFromReducerDict<Inp>>>
 
 export const createRedutser2 = <State>(initialState: State) => <
   Dict extends ReducerDict<State>
@@ -55,7 +55,7 @@ export interface Redutser<State, Dict extends ReducerDict<State>> {
   creators: ActionCreatorsFromReducerDict<Dict>
   reducer: (
     state: State | undefined,
-    action: H.FnReturn<ActionCreatorsFromReducerDict<Dict>[keyof Dict]>
+    action: ReturnType<ActionCreatorsFromReducerDict<Dict>[keyof Dict]>
   ) => State
   initialState: State
   actionTypes: ActionTypesFromReducerDict<Dict>

--- a/type-helpers.d.ts
+++ b/type-helpers.d.ts
@@ -1,6 +1,5 @@
 export type SecondArg<T> = T extends (x: any, y: infer V) => any ? V : never
 export type Values<K> = K[keyof K]
-export type FnReturn<T> = T extends (...x: any[]) => infer V ? V : never
 export type Just<T> = Omit<T, undefined>
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 


### PR DESCRIPTION
Fixes TS 2.9 build

Fixes #1 

Surprisingly this seems to fix #2 too. No need to use `createRedutser2`:) 